### PR TITLE
[DOCS] Fixed a malformed sentence.

### DIFF
--- a/docs/src/reference/asciidoc/core/configuration.adoc
+++ b/docs/src/reference/asciidoc/core/configuration.adoc
@@ -359,7 +359,7 @@ Name of the `ValueWriter` implementation for converting objects to JSON. This is
 
 When using {eh}, it is important to be aware of the following Hadoop configurations that can influence the way Map/Reduce tasks are executed and in return {eh}.
 
-IMPORTANT: Unfortunately, these settings need to be setup *manually* *before* the job / script configuration. Since {eh} is called too late in the life-cycle, after the task has been tasks have been already dispatched and as such, cannot influence the execution anymore.
+IMPORTANT: Unfortunately, these settings need to be setup *manually* *before* the job / script configuration. Since {eh} is called too late in the life-cycle, after the tasks have been already dispatched and as such, cannot influence the execution anymore.
 
 [float]
 === Speculative execution


### PR DESCRIPTION
Corrected a sentence in the documentation, I hope I'm correct in thinking its `tasks` and not `task`.

Regards,
